### PR TITLE
feat: polish dialog UX — escape key, auto-focus, ARIA, leave confirmation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2835,19 +2835,6 @@
         "picomatch": "^4.0.2"
       }
     },
-    "node_modules/@vue/language-core/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/@vue/reactivity": {
       "version": "3.5.30",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.30.tgz",
@@ -4539,6 +4526,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -4682,19 +4682,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/npm-run-all2/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/npm-run-all2/node_modules/which": {
@@ -4863,13 +4850,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -5520,19 +5507,6 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/tinypool": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
@@ -5612,7 +5586,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -5771,19 +5745,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/vite-node/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/vite-node/node_modules/vite": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
@@ -5859,19 +5820,6 @@
         }
       }
     },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/vitest": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
@@ -5943,19 +5891,6 @@
         "jsdom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/vitest/node_modules/vite": {

--- a/frontend/src/components/AuthDialog.vue
+++ b/frontend/src/components/AuthDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { ref, onMounted, onUnmounted, nextTick } from "vue";
 import { useAuthStore } from "@/stores/auth";
 
 const emit = defineEmits<{ close: [] }>();
@@ -9,6 +9,7 @@ const mode = ref<"login" | "register">("login");
 const username = ref("");
 const password = ref("");
 const submitted = ref(false);
+const usernameInput = ref<HTMLInputElement | null>(null);
 
 async function handleSubmit() {
   submitted.value = true;
@@ -23,6 +24,19 @@ async function handleSubmit() {
     emit("close");
   }
 }
+
+function handleEscape(e: KeyboardEvent) {
+  if (e.key === "Escape") emit("close");
+}
+
+onMounted(() => {
+  document.addEventListener("keydown", handleEscape);
+  nextTick(() => usernameInput.value?.focus());
+});
+
+onUnmounted(() => {
+  document.removeEventListener("keydown", handleEscape);
+});
 </script>
 
 <template>
@@ -31,9 +45,12 @@ async function handleSubmit() {
       <div class="fixed inset-0 bg-black/40 backdrop-blur-sm" aria-hidden="true"></div>
 
       <div
+        role="dialog"
+        aria-modal="true"
         class="relative w-full max-w-md rounded-2xl bg-white dark:bg-neutral-800 shadow-2xl border border-neutral-200 dark:border-neutral-700 p-6"
       >
         <button
+          aria-label="Close"
           class="absolute top-4 right-4 text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 hover:scale-110 transition-all"
           @click="$emit('close')"
         >
@@ -101,6 +118,7 @@ async function handleSubmit() {
             </label>
             <input
               id="auth-username"
+              ref="usernameInput"
               v-model="username"
               type="text"
               placeholder="e.g. MaxMuster"

--- a/frontend/src/components/ConfirmDialog.vue
+++ b/frontend/src/components/ConfirmDialog.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref, nextTick } from "vue";
+
+interface Props {
+  title: string;
+  message: string;
+  confirmText?: string;
+  cancelText?: string;
+  destructive?: boolean;
+}
+
+withDefaults(defineProps<Props>(), {
+  confirmText: "Confirm",
+  cancelText: "Cancel",
+  destructive: false,
+});
+
+const emit = defineEmits<{ confirm: []; cancel: [] }>();
+const cancelButton = ref<HTMLButtonElement | null>(null);
+
+function handleEscape(e: KeyboardEvent) {
+  if (e.key === "Escape") emit("cancel");
+}
+
+onMounted(() => {
+  document.addEventListener("keydown", handleEscape);
+  nextTick(() => cancelButton.value?.focus());
+});
+
+onUnmounted(() => {
+  document.removeEventListener("keydown", handleEscape);
+});
+</script>
+
+<template>
+  <Teleport to="body">
+    <div class="fixed inset-0 z-50 flex items-center justify-center p-4" @click.self="$emit('cancel')">
+      <div class="fixed inset-0 bg-black/40 backdrop-blur-sm" aria-hidden="true"></div>
+
+      <div
+        role="dialog"
+        aria-modal="true"
+        class="relative w-full max-w-sm rounded-2xl bg-white dark:bg-neutral-800 shadow-2xl border border-neutral-200 dark:border-neutral-700 p-6"
+      >
+        <h2 class="text-lg font-bold text-neutral-900 dark:text-neutral-100 mb-2">{{ title }}</h2>
+        <p class="text-sm text-neutral-600 dark:text-neutral-400 mb-6">{{ message }}</p>
+
+        <div class="flex gap-3">
+          <button
+            ref="cancelButton"
+            class="flex-1 rounded-xl border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-700 text-neutral-700 dark:text-neutral-300 font-medium py-2.5 text-sm hover:bg-neutral-50 dark:hover:bg-neutral-600 hover:-translate-y-0.5 transition-all duration-200"
+            @click="$emit('cancel')"
+          >
+            {{ cancelText }}
+          </button>
+          <button
+            class="flex-1 rounded-xl text-white font-semibold py-2.5 text-sm hover:-translate-y-0.5 hover:shadow-lg transition-all duration-200"
+            :class="
+              destructive
+                ? 'bg-red-500 hover:bg-red-600 active:bg-red-700 shadow-lg shadow-red-500/25'
+                : 'bg-amber-500 hover:bg-amber-600 active:bg-amber-700 shadow-lg shadow-amber-500/25'
+            "
+            @click="$emit('confirm')"
+          >
+            {{ confirmText }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/frontend/src/components/CreateLobbyDialog.vue
+++ b/frontend/src/components/CreateLobbyDialog.vue
@@ -1,17 +1,31 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { ref, onMounted, onUnmounted, nextTick } from "vue";
 
 const emit = defineEmits<{ create: [name: string, hostName: string]; close: [] }>();
 
 const gameName = ref("");
 const hostName = ref("");
 const submitted = ref(false);
+const gameNameInput = ref<HTMLInputElement | null>(null);
 
 function handleSubmit() {
   submitted.value = true;
   if (!gameName.value.trim() || !hostName.value.trim()) return;
   emit("create", gameName.value.trim(), hostName.value.trim());
 }
+
+function handleEscape(e: KeyboardEvent) {
+  if (e.key === "Escape") emit("close");
+}
+
+onMounted(() => {
+  document.addEventListener("keydown", handleEscape);
+  nextTick(() => gameNameInput.value?.focus());
+});
+
+onUnmounted(() => {
+  document.removeEventListener("keydown", handleEscape);
+});
 </script>
 
 <template>
@@ -20,9 +34,12 @@ function handleSubmit() {
       <div class="fixed inset-0 bg-black/40 backdrop-blur-sm" aria-hidden="true"></div>
 
       <div
+        role="dialog"
+        aria-modal="true"
         class="relative w-full max-w-md rounded-2xl bg-white dark:bg-neutral-800 shadow-2xl border border-neutral-200 dark:border-neutral-700 p-6"
       >
         <button
+          aria-label="Close"
           class="absolute top-4 right-4 text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 hover:scale-110 transition-all"
           @click="$emit('close')"
         >
@@ -45,6 +62,7 @@ function handleSubmit() {
             </label>
             <input
               id="game-name"
+              ref="gameNameInput"
               v-model="gameName"
               type="text"
               placeholder="e.g. Friday Night Game"

--- a/frontend/src/components/JoinLobbyDialog.vue
+++ b/frontend/src/components/JoinLobbyDialog.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Lobby } from "@/composables/useLobby";
-import { ref } from "vue";
+import { ref, watch, onMounted, onUnmounted, nextTick } from "vue";
 
 interface Props {
   lobbies: Lobby[];
@@ -12,6 +12,8 @@ const emit = defineEmits<{ join: [lobbyId: string, playerName: string]; close: [
 const selectedLobby = ref<Lobby | null>(null);
 const playerName = ref("");
 const submitted = ref(false);
+const dialogPanel = ref<HTMLDivElement | null>(null);
+const playerNameInput = ref<HTMLInputElement | null>(null);
 
 function openJoin(lobby: Lobby) {
   selectedLobby.value = lobby;
@@ -19,11 +21,36 @@ function openJoin(lobby: Lobby) {
   submitted.value = false;
 }
 
+watch(selectedLobby, (val) => {
+  if (val) {
+    nextTick(() => playerNameInput.value?.focus());
+  }
+});
+
 function handleSubmit() {
   submitted.value = true;
   if (!playerName.value.trim() || !selectedLobby.value) return;
   emit("join", selectedLobby.value.id, playerName.value.trim());
 }
+
+function handleEscape(e: KeyboardEvent) {
+  if (e.key === "Escape") {
+    if (selectedLobby.value) {
+      selectedLobby.value = null;
+    } else {
+      emit("close");
+    }
+  }
+}
+
+onMounted(() => {
+  document.addEventListener("keydown", handleEscape);
+  nextTick(() => dialogPanel.value?.focus());
+});
+
+onUnmounted(() => {
+  document.removeEventListener("keydown", handleEscape);
+});
 </script>
 
 <template>
@@ -32,9 +59,14 @@ function handleSubmit() {
       <div class="fixed inset-0 bg-black/40 backdrop-blur-sm" aria-hidden="true"></div>
 
       <div
-        class="relative w-full max-w-md rounded-2xl bg-white dark:bg-neutral-800 shadow-2xl border border-neutral-200 dark:border-neutral-700 p-6"
+        ref="dialogPanel"
+        role="dialog"
+        aria-modal="true"
+        tabindex="-1"
+        class="relative w-full max-w-md rounded-2xl bg-white dark:bg-neutral-800 shadow-2xl border border-neutral-200 dark:border-neutral-700 p-6 outline-none"
       >
         <button
+          aria-label="Close"
           class="absolute top-4 right-4 text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 hover:scale-110 transition-all"
           @click="$emit('close')"
         >
@@ -86,6 +118,7 @@ function handleSubmit() {
               </label>
               <input
                 id="player-name"
+                ref="playerNameInput"
                 v-model="playerName"
                 type="text"
                 placeholder="e.g. Max"

--- a/frontend/src/views/GamePage.vue
+++ b/frontend/src/views/GamePage.vue
@@ -5,6 +5,7 @@ import TheBoard from "@/components/TheBoard.vue";
 import GameLog from "@/components/GameLog.vue";
 import ConnectionStatus from "@/components/ConnectionStatus.vue";
 import ChatPanel from "@/components/ChatPanel.vue";
+import ConfirmDialog from "@/components/ConfirmDialog.vue";
 import { useGameStore } from "@/stores/game";
 import { usePlayerSession } from "@/composables/usePlayerSession";
 import { useSoundEffects } from "@/composables/useSoundEffects";
@@ -23,6 +24,7 @@ const { muted: soundMuted, toggleMute } = useSoundEffects();
 const isRematchLoading = ref(false);
 const diceAnimating = ref(false);
 const gameChatPanel = ref<InstanceType<typeof ChatPanel> | null>(null);
+const showLeaveConfirm = ref(false);
 
 watch(
   () => store.lastDiceRoll,
@@ -184,7 +186,7 @@ onUnmounted(() => {
     <header class="px-4 py-3 flex items-center gap-4">
       <button
         class="inline-flex items-center gap-1.5 text-sm font-medium text-amber-700 dark:text-amber-400 hover:text-amber-900 dark:hover:text-amber-300 hover:underline transition-colors"
-        @click="router.push({ name: 'home' })"
+        @click="store.isFinished ? router.push({ name: 'home' }) : (showLeaveConfirm = true)"
       >
         <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
           <path
@@ -382,6 +384,17 @@ onUnmounted(() => {
         </div>
       </div>
     </div>
+
+    <ConfirmDialog
+      v-if="showLeaveConfirm"
+      title="Leave Game?"
+      message="The game is still in progress. Are you sure you want to leave?"
+      confirm-text="Leave"
+      cancel-text="Stay"
+      :destructive="true"
+      @confirm="router.push({ name: 'home' })"
+      @cancel="showLeaveConfirm = false"
+    />
   </div>
 </template>
 

--- a/frontend/src/views/LobbyRoom.vue
+++ b/frontend/src/views/LobbyRoom.vue
@@ -7,6 +7,7 @@ import { usePlayerSession } from "@/composables/usePlayerSession";
 import { apiFetch } from "@/composables/apiFetch";
 import ConnectionStatus from "@/components/ConnectionStatus.vue";
 import ChatPanel from "@/components/ChatPanel.vue";
+import ConfirmDialog from "@/components/ConfirmDialog.vue";
 import type { ChatMessage } from "@/composables/useChat";
 
 const route = useRoute();
@@ -34,6 +35,7 @@ const lobby = ref<LobbyData | null>(null);
 const error = ref<string | null>(null);
 const starting = ref(false);
 const chatPanel = ref<InstanceType<typeof ChatPanel> | null>(null);
+const showLeaveConfirm = ref(false);
 
 const isHost = computed(() => lobby.value?.hostPlayer.id === myPlayerId);
 const canStart = computed(() => (lobby.value?.players.length ?? 0) >= 2);
@@ -193,7 +195,7 @@ const playerColors = ["green", "yellow", "red", "black"] as const;
     <header class="px-4 py-3 flex items-center gap-4">
       <button
         class="inline-flex items-center gap-1.5 text-sm font-medium text-amber-700 dark:text-amber-400 hover:text-amber-900 dark:hover:text-amber-300 hover:underline transition-colors"
-        @click="router.push({ name: 'home' })"
+        @click="showLeaveConfirm = true"
       >
         <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
           <path
@@ -328,5 +330,16 @@ const playerColors = ["green", "yellow", "red", "black"] as const;
         />
       </div>
     </main>
+
+    <ConfirmDialog
+      v-if="showLeaveConfirm"
+      title="Leave Lobby?"
+      message="Are you sure you want to leave? Other players may be waiting for you."
+      confirm-text="Leave"
+      cancel-text="Stay"
+      :destructive="true"
+      @confirm="router.push({ name: 'home' })"
+      @cancel="showLeaveConfirm = false"
+    />
   </div>
 </template>


### PR DESCRIPTION
## Dialog & Modal Polish

- **Escape key** closes AuthDialog, CreateLobbyDialog, JoinLobbyDialog (JoinLobbyDialog: first Escape goes back to lobby list, second closes)
- **Auto-focus** first input field when dialogs open
- **ARIA attributes**: `role="dialog"`, `aria-modal="true"` on all dialog panels; `aria-label="Close"` on dismiss buttons
- **New `ConfirmDialog` component**: reusable confirmation modal with destructive/normal styling
- **Leave confirmation**: LobbyRoom and GamePage show confirm dialog before navigating away (skipped if game is already finished)

All 154 unit tests pass.