### PR TITLE
feat: add loading skeletons, error states, and button loading indicators

### DIFF
--- a/frontend/src/components/ChatPanel.vue
+++ b/frontend/src/components/ChatPanel.vue
@@ -15,9 +15,10 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<{ "update:collapsed": [value: boolean] }>();
 
-const { messages, fetchMessages, sendMessage, addMessage } = useChat();
+const { messages, loading, error, fetchMessages, sendMessage, addMessage } = useChat();
 const inputText = ref("");
 const sending = ref(false);
+const sendError = ref<string | null>(null);
 const messagesContainer = ref<HTMLElement | null>(null);
 const isOpen = ref(!props.collapsed);
 
@@ -44,9 +45,12 @@ async function handleSend() {
   if (!text || sending.value) return;
 
   sending.value = true;
+  sendError.value = null;
   const success = await sendMessage(props.context, props.contextId, props.myPlayerId, text);
   if (success) {
     inputText.value = "";
+  } else {
+    sendError.value = error.value ?? "Failed to send message";
   }
   sending.value = false;
 }
@@ -96,7 +100,10 @@ defineExpose({ addMessage });
         ref="messagesContainer"
         class="h-48 overflow-y-auto px-3 py-2 space-y-1.5 text-sm"
       >
-        <div v-if="messages.length === 0" class="text-center text-neutral-400 dark:text-neutral-500 text-xs py-6">
+        <div v-if="loading" class="flex justify-center py-6">
+          <div class="h-5 w-5 animate-spin rounded-full border-2 border-amber-300 border-t-amber-600"></div>
+        </div>
+        <div v-else-if="messages.length === 0" class="text-center text-neutral-400 dark:text-neutral-500 text-xs py-6">
           No messages yet. Say hi! 👋
         </div>
         <div
@@ -122,6 +129,11 @@ defineExpose({ addMessage });
             </p>
           </div>
         </div>
+      </div>
+
+      <!-- Send error -->
+      <div v-if="sendError" class="px-3 py-1.5 text-xs text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 border-t border-red-200 dark:border-red-800">
+        {{ sendError }}
       </div>
 
       <!-- Input -->

--- a/frontend/src/components/CreateLobbyDialog.vue
+++ b/frontend/src/components/CreateLobbyDialog.vue
@@ -1,6 +1,14 @@
 <script setup lang="ts">
 import { ref } from "vue";
 
+interface Props {
+  loading?: boolean;
+}
+
+withDefaults(defineProps<Props>(), {
+  loading: false,
+});
+
 const emit = defineEmits<{ create: [name: string, hostName: string]; close: [] }>();
 
 const gameName = ref("");
@@ -81,9 +89,14 @@ function handleSubmit() {
             </button>
             <button
               type="submit"
-              class="flex-1 rounded-xl bg-amber-500 hover:bg-amber-600 active:bg-amber-700 text-white font-semibold py-2.5 text-sm hover:-translate-y-0.5 hover:shadow-lg transition-all duration-200"
+              :disabled="loading"
+              class="flex-1 rounded-xl bg-amber-500 hover:bg-amber-600 active:bg-amber-700 text-white font-semibold py-2.5 text-sm hover:-translate-y-0.5 hover:shadow-lg transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0 disabled:hover:shadow-none"
             >
-              Create Game
+              <span v-if="loading" class="inline-flex items-center gap-1.5">
+                <span class="inline-block w-3.5 h-3.5 border-2 border-white border-t-transparent rounded-full animate-spin"></span>
+                Creating…
+              </span>
+              <span v-else>Create Game</span>
             </button>
           </div>
         </form>

--- a/frontend/src/components/JoinLobbyDialog.vue
+++ b/frontend/src/components/JoinLobbyDialog.vue
@@ -4,9 +4,12 @@ import { ref } from "vue";
 
 interface Props {
   lobbies: Lobby[];
+  loading?: boolean;
 }
 
-defineProps<Props>();
+withDefaults(defineProps<Props>(), {
+  loading: false,
+});
 const emit = defineEmits<{ join: [lobbyId: string, playerName: string]; close: [] }>();
 
 const selectedLobby = ref<Lobby | null>(null);
@@ -108,9 +111,14 @@ function handleSubmit() {
               </button>
               <button
                 type="submit"
-                class="flex-1 rounded-xl bg-amber-500 hover:bg-amber-600 active:bg-amber-700 text-white font-semibold py-2.5 text-sm hover:-translate-y-0.5 hover:shadow-lg transition-all duration-200"
+                :disabled="loading"
+                class="flex-1 rounded-xl bg-amber-500 hover:bg-amber-600 active:bg-amber-700 text-white font-semibold py-2.5 text-sm hover:-translate-y-0.5 hover:shadow-lg transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0 disabled:hover:shadow-none"
               >
-                Join
+                <span v-if="loading" class="inline-flex items-center gap-1.5">
+                  <span class="inline-block w-3.5 h-3.5 border-2 border-white border-t-transparent rounded-full animate-spin"></span>
+                  Joining…
+                </span>
+                <span v-else>Join</span>
               </button>
             </div>
           </form>

--- a/frontend/src/components/LobbyList.vue
+++ b/frontend/src/components/LobbyList.vue
@@ -42,8 +42,23 @@ defineEmits<{ join: [lobbyId: string]; refresh: [] }>();
       {{ error }}
     </div>
 
-    <div v-if="loading && lobbies.length === 0" class="flex justify-center py-12">
-      <div class="h-8 w-8 animate-spin rounded-full border-4 border-amber-300 border-t-amber-600"></div>
+    <div v-if="loading && lobbies.length === 0" class="grid gap-4 sm:grid-cols-2">
+      <div v-for="i in 4" :key="'skeleton-' + i" class="rounded-2xl bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 p-5 shadow-sm animate-pulse">
+        <div class="flex items-start justify-between gap-3">
+          <div class="min-w-0 flex-1">
+            <div class="h-5 w-3/4 rounded bg-neutral-200 dark:bg-neutral-700"></div>
+            <div class="mt-2 h-3 w-1/3 rounded bg-neutral-200 dark:bg-neutral-700"></div>
+          </div>
+          <div class="h-5 w-12 rounded-full bg-neutral-200 dark:bg-neutral-700"></div>
+        </div>
+        <div class="mt-4 flex items-center gap-3">
+          <div class="flex -space-x-1.5">
+            <div class="w-7 h-7 rounded-full bg-neutral-200 dark:bg-neutral-700 border-2 border-white dark:border-neutral-800"></div>
+          </div>
+          <div class="h-3 w-24 rounded bg-neutral-200 dark:bg-neutral-700"></div>
+        </div>
+        <div class="mt-4 h-10 rounded-xl bg-neutral-200 dark:bg-neutral-700"></div>
+      </div>
     </div>
 
     <div v-else-if="lobbies.length === 0" class="text-center py-12">

--- a/frontend/src/views/GamePage.vue
+++ b/frontend/src/views/GamePage.vue
@@ -206,9 +206,30 @@ onUnmounted(() => {
       </button>
     </header>
 
-    <!-- Loading -->
-    <div v-if="store.isLoading && !store.gameState" class="flex justify-center items-center h-64">
-      <p class="text-neutral-500 dark:text-neutral-400 animate-pulse">Loading game…</p>
+    <!-- Loading Skeleton -->
+    <div v-if="store.isLoading && !store.gameState" class="flex flex-col lg:flex-row gap-4 px-4 pb-8 max-w-[1200px] mx-auto">
+      <div class="flex-1 min-w-0">
+        <div class="bg-amber-200/50 dark:bg-amber-900/50 p-2 rounded border-[3px] border-red-600/30 mx-auto animate-pulse" style="max-width: 700px">
+          <div class="p-4 border-2 border-black/10 dark:border-neutral-300/10 rounded-sm aspect-square"></div>
+        </div>
+      </div>
+      <aside class="w-full lg:w-72 flex flex-col gap-4 animate-pulse">
+        <div class="rounded-xl bg-white dark:bg-neutral-800 shadow-md border border-neutral-200 dark:border-neutral-700 p-4">
+          <div class="h-4 w-24 rounded bg-neutral-200 dark:bg-neutral-700 mb-3"></div>
+          <div class="h-6 w-32 rounded bg-neutral-200 dark:bg-neutral-700"></div>
+        </div>
+        <div class="rounded-xl bg-white dark:bg-neutral-800 shadow-md border border-neutral-200 dark:border-neutral-700 p-4">
+          <div class="h-16 w-16 rounded-full bg-neutral-200 dark:bg-neutral-700 mx-auto mb-3"></div>
+          <div class="h-10 w-full rounded-lg bg-neutral-200 dark:bg-neutral-700"></div>
+        </div>
+        <div class="rounded-xl bg-white dark:bg-neutral-800 shadow-md border border-neutral-200 dark:border-neutral-700 p-4">
+          <div class="h-4 w-20 rounded bg-neutral-200 dark:bg-neutral-700 mb-3"></div>
+          <div class="space-y-2">
+            <div class="h-8 w-full rounded-lg bg-neutral-200 dark:bg-neutral-700"></div>
+            <div class="h-8 w-full rounded-lg bg-neutral-200 dark:bg-neutral-700"></div>
+          </div>
+        </div>
+      </aside>
     </div>
 
     <!-- Error -->

--- a/frontend/src/views/HomePage.vue
+++ b/frontend/src/views/HomePage.vue
@@ -20,6 +20,8 @@ const showCreateDialog = ref(false);
 const showJoinDialog = ref(false);
 const showAuthDialog = ref(false);
 const activeSession = ref<PlayerSession | null>(null);
+const creating = ref(false);
+const joining = ref(false);
 
 onMounted(async () => {
   fetchLobbies();
@@ -45,7 +47,9 @@ onMounted(async () => {
 });
 
 async function handleCreate(name: string, hostName: string) {
+  creating.value = true;
   const lobby = await createLobby(name, hostName);
+  creating.value = false;
   if (lobby) {
     showCreateDialog.value = false;
     router.push({
@@ -61,7 +65,9 @@ async function handleJoinFromList() {
 }
 
 async function handleJoin(lobbyId: string, playerName: string) {
+  joining.value = true;
   const lobby = await joinLobby(lobbyId, playerName);
+  joining.value = false;
   if (lobby) {
     showJoinDialog.value = false;
     const players = lobby.players ?? [];
@@ -227,8 +233,8 @@ function dismissSession() {
     </section>
 
     <!-- Dialogs -->
-    <CreateLobbyDialog v-if="showCreateDialog" @create="handleCreate" @close="showCreateDialog = false" />
-    <JoinLobbyDialog v-if="showJoinDialog" :lobbies="lobbies" @join="handleJoin" @close="showJoinDialog = false" />
+    <CreateLobbyDialog v-if="showCreateDialog" :loading="creating" @create="handleCreate" @close="showCreateDialog = false" />
+    <JoinLobbyDialog v-if="showJoinDialog" :lobbies="lobbies" :loading="joining" @join="handleJoin" @close="showJoinDialog = false" />
     <AuthDialog v-if="showAuthDialog" @close="showAuthDialog = false" />
   </div>
 </template>

--- a/frontend/src/views/LobbyRoom.vue
+++ b/frontend/src/views/LobbyRoom.vue
@@ -279,10 +279,11 @@ const playerColors = ["green", "yellow", "red", "black"] as const;
             <button
               v-if="isHost && canAddBot"
               :disabled="addingBot"
-              class="w-full flex items-center justify-center gap-2 p-3 rounded-xl border-2 border-dashed border-amber-300 dark:border-amber-600 text-amber-600 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/20 hover:-translate-y-0.5 transition-all duration-200 font-medium text-sm"
+              class="w-full flex items-center justify-center gap-2 p-3 rounded-xl border-2 border-dashed border-amber-300 dark:border-amber-600 text-amber-600 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/20 hover:-translate-y-0.5 transition-all duration-200 font-medium text-sm disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0"
               @click="handleAddBot"
             >
-              <span>🤖</span>
+              <span v-if="addingBot" class="inline-block w-4 h-4 border-2 border-amber-500 border-t-transparent rounded-full animate-spin"></span>
+              <span v-else>🤖</span>
               {{ addingBot ? "Adding..." : "Add Bot" }}
             </button>
           </div>


### PR DESCRIPTION
## Loading, Error & Empty States

- **Lobby list skeleton**: Shows 4 animated skeleton cards while lobbies load (replaces plain spinner)
- **Game page skeleton**: Full layout skeleton (board area + HUD panels) while game state loads
- **Chat loading state**: Spinner while messages are being fetched
- **Chat send error**: Inline error message when sending a message fails
- **Create/Join dialog loading**: `loading` prop with spinner and disabled submit button
- **Add Bot button**: Spinner icon + disabled styling during request

All 154 unit tests pass.