### PR TITLE
feat: improve accessibility — ARIA labels, live regions, screen reader support

### DIFF
--- a/frontend/src/components/ConnectionStatus.vue
+++ b/frontend/src/components/ConnectionStatus.vue
@@ -11,7 +11,7 @@ withDefaults(defineProps<Props>(), {
 </script>
 
 <template>
-  <div class="inline-flex items-center gap-1.5 text-xs font-medium">
+  <div class="inline-flex items-center gap-1.5 text-xs font-medium" role="status" aria-live="polite">
     <!-- Connected: subtle green dot -->
     <template v-if="status === 'connected'">
       <span class="w-2 h-2 rounded-full bg-green-500" aria-hidden="true"></span>

--- a/frontend/src/components/GameLog.vue
+++ b/frontend/src/components/GameLog.vue
@@ -61,7 +61,7 @@ function formatEvent(event: GameEvent): string {
     <h3 class="text-xs font-semibold text-neutral-500 dark:text-neutral-400 uppercase tracking-wide mb-2">
       Game Log
     </h3>
-    <div ref="logContainer" class="flex-1 overflow-y-auto space-y-1 min-h-0 max-h-48 pr-1 scrollbar-thin">
+    <div ref="logContainer" class="flex-1 overflow-y-auto space-y-1 min-h-0 max-h-48 pr-1 scrollbar-thin" aria-live="polite" aria-relevant="additions">
       <p v-if="events.length === 0" class="text-xs text-neutral-400 dark:text-neutral-500 italic">
         No actions yet...
       </p>

--- a/frontend/src/components/LobbyList.vue
+++ b/frontend/src/components/LobbyList.vue
@@ -19,6 +19,7 @@ defineEmits<{ join: [lobbyId: string]; refresh: [] }>();
       <button
         class="inline-flex items-center gap-1.5 text-sm font-medium text-amber-600 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-300 hover:underline transition-colors"
         :disabled="loading"
+        aria-label="Refresh lobby list"
         @click="$emit('refresh')"
       >
         <svg

--- a/frontend/src/views/GamePage.vue
+++ b/frontend/src/views/GamePage.vue
@@ -200,6 +200,7 @@ onUnmounted(() => {
       <button
         class="text-lg hover:scale-110 hover:opacity-80 transition-all"
         :title="soundMuted ? 'Unmute sounds' : 'Mute sounds'"
+        :aria-label="soundMuted ? 'Unmute sounds' : 'Mute sounds'"
         @click="toggleMute"
       >
         {{ soundMuted ? "🔇" : "🔊" }}
@@ -220,7 +221,7 @@ onUnmounted(() => {
     <!-- Game layout -->
     <main v-else class="flex flex-col lg:flex-row gap-4 px-4 pb-8 max-w-[1200px] mx-auto">
       <!-- Board column -->
-      <div class="flex-1 min-w-0">
+      <div class="flex-1 min-w-0" role="status" aria-live="polite">
         <!-- Action toast -->
         <Transition name="toast">
           <div
@@ -326,9 +327,9 @@ onUnmounted(() => {
                 </span>
               </span>
               <div class="flex gap-2 text-xs text-neutral-500">
-                <span title="In base">🏠{{ ps.inBase }}</span>
-                <span title="On path">🛤️{{ ps.onPath }}</span>
-                <span title="In goal">🏁{{ ps.inGoal }}</span>
+                <span title="In base" :aria-label="ps.inBase + ' pieces in base'">🏠{{ ps.inBase }}</span>
+                <span title="On path" :aria-label="ps.onPath + ' pieces on path'">🛤️{{ ps.onPath }}</span>
+                <span title="In goal" :aria-label="ps.inGoal + ' pieces in goal'">🏁{{ ps.inGoal }}</span>
               </div>
             </div>
           </div>

--- a/frontend/src/views/HomePage.vue
+++ b/frontend/src/views/HomePage.vue
@@ -171,6 +171,7 @@ function dismissSession() {
                 class="text-green-600 dark:text-green-400 hover:text-green-800 dark:hover:text-green-200 text-xs hover:scale-110 transition-transform"
                 @click="dismissSession"
                 title="Dismiss"
+                aria-label="Dismiss session"
               >
                 ✕
               </button>


### PR DESCRIPTION
## Accessibility Improvements

- **`aria-label`** on icon-only buttons: sound toggle, dismiss session, refresh lobby list
- **`role="status"` + `aria-live="polite"`** on ConnectionStatus for screen reader announcements
- **`aria-live="polite"`** on GameLog and toast notification area
- **Descriptive `aria-label`** on piece stat emojis (e.g. '2 pieces in base', '1 piece on path')
- Color name labels already present in LobbyRoom player list

All 154 unit tests pass.