### PR TITLE
feat: add visual feedback and animation polish

### DIFF
--- a/frontend/src/components/ConnectionStatus.vue
+++ b/frontend/src/components/ConnectionStatus.vue
@@ -11,7 +11,17 @@ withDefaults(defineProps<Props>(), {
 </script>
 
 <template>
-  <div class="inline-flex items-center gap-1.5 text-xs font-medium">
+  <!-- Disconnected: prominent warning banner -->
+  <div
+    v-if="status === 'disconnected'"
+    class="flex items-center justify-center gap-2 text-sm font-semibold py-2 px-4 rounded-lg bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300 border border-red-300 dark:border-red-700"
+  >
+    <span class="w-2.5 h-2.5 rounded-full bg-red-500 animate-pulse" aria-hidden="true"></span>
+    Disconnected — trying to reconnect…
+  </div>
+
+  <!-- Non-disconnected states: compact inline indicator -->
+  <div v-else class="inline-flex items-center gap-1.5 text-xs font-medium">
     <!-- Connected: subtle green dot -->
     <template v-if="status === 'connected'">
       <span class="w-2 h-2 rounded-full bg-green-500" aria-hidden="true"></span>
@@ -24,12 +34,6 @@ withDefaults(defineProps<Props>(), {
       <span class="text-amber-600 dark:text-amber-400">
         {{ status === "reconnecting" ? "Reconnecting…" : "Connecting…" }}
       </span>
-    </template>
-
-    <!-- Disconnected: red persistent -->
-    <template v-else-if="status === 'disconnected'">
-      <span class="w-2 h-2 rounded-full bg-red-500" aria-hidden="true"></span>
-      <span class="text-red-600 dark:text-red-400">Disconnected</span>
     </template>
 
     <!-- Idle: nothing shown -->

--- a/frontend/src/views/GamePage.vue
+++ b/frontend/src/views/GamePage.vue
@@ -19,10 +19,11 @@ const router = useRouter();
 const gameId = route.params.id as string;
 const store = useGameStore();
 const { loadSession, updateSession } = usePlayerSession();
-const { muted: soundMuted, toggleMute } = useSoundEffects();
+const { play: playSound, muted: soundMuted, toggleMute } = useSoundEffects();
 const isRematchLoading = ref(false);
 const diceAnimating = ref(false);
 const gameChatPanel = ref<InstanceType<typeof ChatPanel> | null>(null);
+const showRematchDialog = ref(false);
 
 watch(
   () => store.lastDiceRoll,
@@ -42,6 +43,28 @@ const colorLabels: Record<PlayerColor, string> = {
   red: "🔴 Red",
   black: "⚫ Black",
 };
+
+// Play turn notification sound when it becomes the player's turn
+watch(
+  () => store.isMyTurn,
+  (isMyTurn, wasMyTurn) => {
+    if (isMyTurn && !wasMyTurn) {
+      playSound("turn");
+    }
+  },
+);
+
+// Show rematch dialog with a delay after game finishes
+watch(
+  () => store.isFinished,
+  (finished) => {
+    if (finished) {
+      setTimeout(() => {
+        showRematchDialog.value = true;
+      }, 1500);
+    }
+  },
+);
 
 const pieceSummary = computed(() => {
   if (!store.gameState) return [];
@@ -67,7 +90,7 @@ watch(
     if (toastTimeout) clearTimeout(toastTimeout);
     toastTimeout = setTimeout(() => {
       lastActionToast.value = null;
-    }, 3000);
+    }, 5000);
   },
 );
 
@@ -225,8 +248,8 @@ onUnmounted(() => {
         <Transition name="toast">
           <div
             v-if="lastActionToast"
-            class="mb-3 mx-auto text-center text-sm font-medium py-2 px-4 rounded-lg bg-white dark:bg-neutral-800 shadow-lg border border-neutral-200 dark:border-neutral-700"
-            style="max-width: 700px"
+            class="mb-3 mx-auto max-w-[700px] text-center text-sm font-medium py-2 px-4 rounded-lg bg-white dark:bg-neutral-800 shadow-lg border border-neutral-200 dark:border-neutral-700"
+           
           >
             {{ lastActionToast }}
           </div>
@@ -235,14 +258,14 @@ onUnmounted(() => {
         <!-- Bot thinking banner -->
         <div
           v-if="store.botThinking"
-          class="mb-3 mx-auto text-center text-sm font-medium py-2 px-4 rounded-lg bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 animate-pulse"
-          style="max-width: 700px"
+          class="mb-3 mx-auto max-w-[700px] text-center text-sm font-medium py-2 px-4 rounded-lg bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 animate-pulse"
+         
         >
           <span class="inline-block w-3 h-3 border-2 border-amber-500 border-t-transparent rounded-full animate-spin mr-1.5"></span>
           🤖 Bot is thinking...
         </div>
 
-        <div class="bg-amber-200 dark:bg-amber-900 p-2 rounded border-[3px] border-red-600 mx-auto" style="max-width: 700px">
+        <div class="bg-amber-200 dark:bg-amber-900 p-2 rounded border-[3px] border-red-600 mx-auto max-w-[700px]">
           <div class="p-4 h-full border-2 border-black dark:border-neutral-300 rounded-sm">
             <TheBoard
               :game-state="store.gameState"
@@ -357,7 +380,8 @@ onUnmounted(() => {
     </main>
 
     <!-- Win dialog -->
-    <div v-if="store.isFinished && store.winner" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+    <Transition name="fade">
+      <div v-if="store.isFinished && store.winner && showRematchDialog" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
       <div class="bg-white dark:bg-neutral-800 rounded-2xl shadow-2xl p-8 text-center max-w-sm mx-4">
         <div class="text-6xl mb-4">🏆</div>
         <h2 class="text-2xl font-bold text-neutral-900 dark:text-neutral-100 mb-2">Game Over!</h2>
@@ -381,7 +405,8 @@ onUnmounted(() => {
           </button>
         </div>
       </div>
-    </div>
+      </div>
+    </Transition>
   </div>
 </template>
 
@@ -396,6 +421,17 @@ onUnmounted(() => {
 .toast-leave-to {
   opacity: 0;
   transform: translateY(-8px);
+}
+
+.fade-enter-active {
+  transition: opacity 0.3s ease-out;
+}
+.fade-leave-active {
+  transition: opacity 0.2s ease-in;
+}
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
 }
 
 .dice-roll {


### PR DESCRIPTION
## Visual Feedback & Animation

- **Turn notification sound**: Plays the 'turn' chime when it becomes the player's turn
- **Rematch dialog delay**: 1.5s delay after game ends so the win fanfare plays before showing rematch options; dialog fades in smoothly
- **Connection status banner**: Disconnected state now shows a prominent red warning banner instead of tiny inline text
- **Tailwind classes**: Replaced 3 hardcoded `style="max-width: 700px"` with `max-w-[700px]` Tailwind classes
- **Toast timing**: Increased auto-dismiss from 3s to 5s for better readability

All 154 unit tests pass. Type-check clean.