### PR TITLE
fix: update CI to use PHP 8.5 to match project requirements

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.4
+          php-version: 8.5
           extensions: pdo_pgsql, intl, zip
           tools: composer:v2
 


### PR DESCRIPTION
## Problem

Backend CI was failing with:
```
Root composer.json requires php >=8.5.3 but your php version (8.4.18) does not satisfy that requirement.
```

The CI was configured to use PHP 8.4, but the project targets PHP 8.5 (`FROM dunglas/frankenphp:1-php8.5` in Dockerfile, `"php": ">=8.5.3"` in composer.json).

## Fix

Changed `php-version: 8.4` → `php-version: 8.5` in `.github/workflows/backend.yml` to align CI with the project's actual runtime environment.